### PR TITLE
Fix "Even Calls only" code in browser debugging tricks

### DIFF
--- a/src/content/articles/browser-debugging-tricks/index.mdx
+++ b/src/content/articles/browser-debugging-tricks/index.mdx
@@ -97,7 +97,7 @@ Pause based on computed CSS values, e.g. only pause execution when the document 
 ### Even Calls Only
 
 Only pause every other time the line is executed:
-`window.counter = window.counter || 0, window.counter % 2 === 0`
+`window.counter = (window.counter || 0) + 1, window.counter % 2 === 0`
 
 ### Break on Sample
 


### PR DESCRIPTION
The current code always sets `window.counter` to `0`, causing the condition to pass every time. This change makes the condition pass every other time, as intended.